### PR TITLE
Remove pointer events for players

### DIFF
--- a/Fog.js
+++ b/Fog.js
@@ -1018,8 +1018,10 @@ function drawing_mouseup(e) {
 			c++;
 			// TOKEN IS INSIDE THE SELECTION
 			if (window.DM || !curr.options.hidden) {
+				if($("#tokens>div[data-id='" + curr.options.id + "']").css("pointer-events")!="none") {
+					curr.selected = true;
+				}
 				// DM can always select tokens, but players can only select non-hidden tokens
-				curr.selected = true;
 			}
 			//$("#tokens div[data-id='"+id+"']").addClass("tokenselected").css("border","2px solid white");
 			curr.place();

--- a/Token.js
+++ b/Token.js
@@ -1229,15 +1229,15 @@ function toggle_player_selectable(tokenInstance, token){
 	if (!window.DM){
 		console.log("bain not the DM")
 		if (tokenInstance.options.locked && tokenInstance.options.restrictPlayerMove && $(".body-rpgcharacter-sheet").length>0){
-			token.find("img").css("cursor","default")
-			token.find("img").css("pointer-events","none")
+			token.css("cursor","default");
+			token.css("pointer-events","none");
 		}
 		else{
-			token.find("img").css("cursor","move")
-			token.find("img").css("pointer-events","auto")
+			token.css("cursor","move");
+			token.css("pointer-events","auto");
 		}
 	}
-	console.groupEnd()
+	console.groupEnd();
 }
 
 // Stop the right click mouse down from cancelling our drag

--- a/Token.js
+++ b/Token.js
@@ -365,6 +365,7 @@ class Token {
 			this.update_dead_cross(old)
 			this.update_health_aura(old)
 		}
+		toggle_player_selectable(this, old)
 		console.groupEnd()
 	}
 
@@ -751,6 +752,7 @@ class Token {
 
 			if (this.selected) {
 				old.addClass("tokenselected");
+				toggle_player_selectable(this, old)
 			}
 			else {
 				old.css("border", "");
@@ -1163,6 +1165,7 @@ class Token {
 				}
 				if (thisSelected == true) {
 					parentToken.addClass('tokenselected');
+					toggle_player_selectable(window.TOKEN_OBJECTS[tokID], parentToken)
 				} else {
 					parentToken.removeClass('tokenselected');
 				}				
@@ -1187,6 +1190,7 @@ class Token {
 		let token = $("#tokens").find(selector);
 		this.update_health_aura(token)
 		this.update_dead_cross(token)
+		toggle_player_selectable(this, token)
 		check_token_visibility(); // CHECK FOG OF WAR VISIBILITY OF TOKEN
 		console.groupEnd()
 	}
@@ -1218,6 +1222,22 @@ class Token {
 		return storedValue;
 	}
 	
+}
+
+function toggle_player_selectable(tokenInstance, token){
+	console.group("toggle_player_selectable", tokenInstance)
+	if (!window.DM){
+		console.log("bain not the DM")
+		if (tokenInstance.options.locked && tokenInstance.options.restrictPlayerMove && $(".body-rpgcharacter-sheet").length>0){
+			token.find("img").css("cursor","default")
+			token.find("img").css("pointer-events","none")
+		}
+		else{
+			token.find("img").css("cursor","move")
+			token.find("img").css("pointer-events","auto")
+		}
+	}
+	console.groupEnd()
 }
 
 // Stop the right click mouse down from cancelling our drag


### PR DESCRIPTION
This removes pointer events for players only when a token is locked and restricted. It should help you get to what your looking for I think